### PR TITLE
Remove source maps from the built file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-immutable",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Immutable structurally typed data",
   "author": "Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)",
   "homepage": "https://github.com/gozala/typed-immutable",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "test": "tap lib/test/*.js",
     "start": "babel --watch --optional spec.protoToAssign --modules umdStrict --source-maps inline --out-dir ./lib ./src",
-    "build": "babel --optional spec.protoToAssign --modules umdStrict --source-maps inline --out-dir ./lib ./src",
+    "build": "babel --optional spec.protoToAssign --modules umdStrict --out-dir ./lib ./src",
     "prepublish": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
Source maps aren't really useful if you're just trying to use the library rather than develop it, and I find that the source maps are actually causing issues in my particular webpack setup; if I add a `debugger` line in my code, Chrome dev tools try and jump to a nonexistent line in list.js in this project.
